### PR TITLE
Feature/enhancement/docker port standardization

### DIFF
--- a/doc/User_Manual.md
+++ b/doc/User_Manual.md
@@ -113,20 +113,22 @@ We advice you to try BioSpring with MDDriver and VMD to understand how this inte
 
 To run BioSpring with VMD and MDDriver, start by launching the BioSpring tools with these MDDriver parameters.
 
-	biospring -c model.nc -s param.msp --wait --port 3000 --log model.log
+	biospring -c model.nc -s param.msp --wait --port 8888 --log model.log
 
 Or run the Docker image:
 
-	docker run --rm -p 3000:3000 --init -v ./:/data ghcr.io/lbt-cnrs/biospring \
-		biospring -s model.nc -c param.msp --wait --port 3000
+	docker run --rm -p 8888:8888 --init -v ./:/data ghcr.io/lbt-cnrs/biospring \
+		biospring -s model.nc -c param.msp --wait --port 8888
 
-Use an alias for convenience:  
+Or use an alias for convenience:  
 You can simplify the command by creating an alias and run the image with a shorter command:
 
-	alias biospring-run='docker run --rm -p 3000:3000 --init -v ./:/data ghcr.io/lbt-cnrs/biospring biospring'
+	alias biospring-run='docker run --rm -p 8888:8888 --init -v ./:/data ghcr.io/lbt-cnrs/biospring biospring'
 
-	biospring-run -s model.nc -c param.msp --wait --port 3000
+	biospring-run -s model.nc -c param.msp --wait --port 8888
 
+Or reuse the Makefile in the example directory:  
+Copy the file `example/base.mk` and some of other Makefile in example subdir as template for your own system (see README in example directory for usage)
 
 #### Lauching VMD
 Start the VMD program (double click on its icon or launch from the command line).

--- a/example/README.md
+++ b/example/README.md
@@ -1,24 +1,52 @@
-# Usage:
+# Usage
 
-## Step 1: Server side
-- `make prep`
-- `make expose_data`
-  
-## Step 2: Client side
-- `make get_data`
-  
-## Step 3: Server side
-- CTRL + C to stop the server exposing the data
-- `make run` / `make run_now`
-    - Check the line in the shell and note the `HOSTNAME` and `PORT`:
+## Client and server on the same machine
+
+  - ```bash
+	make prep
+	make run
+	```
+  - Check the line in the shell and note the `HOSTNAME` and `PORT`:
       ```bash
       MDDriver > Interactive MD bind to /[HOSTNAME]/[PORT]
       ```
   
-## Step 4: Client side
-- Open `model.nc` or `model.pdb` in VMD or UnityMol
-- Connect to the server using the `HOSTNAME` and `PORT`
+  - In VMD: open `model.pdb`
+  - In UnityMol:  open `model.nc` or `model.pdb`
+  - Connect to the server using the `HOSTNAME` and `PORT`
+  - CTRL + C to stop the server running the simulation
+  - ```bash
+	make clean
+	```
+
+## Client and server on different machines
+
+- Step 1: Server side ⚙️
+
+		make prep
+		make expose_data
+
+
+- Step 2: Client side 🖥️
+  	
+		make get_data
   
-## Step 5: Server side
-- CTRL + C to stop the server running the simulation
-- `make clean`
+- Step 3: Server side ⚙️
+  - CTRL + C to stop the server exposing the data
+  - ```bash 
+	make run
+	```
+  - Check the line in the shell and note the `HOSTNAME` and `PORT`:
+      ```bash
+      MDDriver > Interactive MD bind to /[HOSTNAME]/[PORT]
+      ```
+  
+- Step 4: Client side 🖥️
+  - In VMD: open `model.pdb`
+  - In UnityMol:  open `model.nc` or `model.pdb`
+  - Connect to the server using the `HOSTNAME` and `PORT`
+  
+- Step 5: Server side ⚙️
+  - CTRL + C to stop the server running the simulation
+  - ```bash
+	make clean

--- a/example/base.mk
+++ b/example/base.mk
@@ -97,7 +97,7 @@ run:
 	HOSTNAME=$$(hostname); \
 	echo "$(GREEN)✅ BioSpring container started successfully!$(RESET)"; \
 	echo ""; \
-	echo "$(YELLOW)⚠️  Before continuing, please note that the BioSpring program is running in idle mode within the container, waiting for a connection. By proceeding, we will reattach to the container and display BioSpring's logs in real-time. Afterward, you can use the following information to connect:$(RESET)"; \
+	echo "$(YELLOW)⚠️  Before continuing, please note that the BioSpring program is running now in idle mode within the container, waiting for a connection. By proceeding, we will reattach to the container and display BioSpring's logs in real-time. Afterward, you can use the following information to connect:$(RESET)"; \
 	echo ""; \
 	echo "  - On the local machine: $(GREEN)localhost:8888$(RESET) or $(GREEN)127.0.0.1:8888$(RESET)"; \
 	echo "  - On the network: $(GREEN)$$HOSTNAME:8888$(RESET)"; \

--- a/example/base.mk
+++ b/example/base.mk
@@ -89,16 +89,16 @@ clean:
 #        even viscosity).
 run : 
 	@echo "Run BioSpring"
-	docker run --network host --rm --init -v $(PWD):/data $(IMAGE) \
+	docker run -p 8888:8888 --rm --init -v $(PWD):/data $(IMAGE) \
 	$(BIOSPRING) -s $(NC) \
 				 -c $(MSP) \
-				 --wait --port 3000 \
+				 --wait --port 8888 \
 				 --sasa-classifier biospring
 
 # Run the BioSpring simulation without waiting for the connection
 run_now:
 	@echo "Run BioSpring NOOOW !!!!"
-	docker run --network host --rm --init -v $(PWD):/data $(IMAGE) \
+	docker run -p 8888:8888 --rm --init -v $(PWD):/data $(IMAGE) \
 	$(BIOSPRING) -s $(NC) \
 				 -c $(MSP) \
 				 --sasa-classifier biospring
@@ -111,7 +111,7 @@ expose_data:
 	@echo "Host machine: $(GREEN)$(shell hostname)$(RESET)"
 	@echo "On the client side, you can retrive the data with the following command:"
 	@echo "\n    $(GREEN)make get_data HOSTNAME=$(shell hostname)$(RESET)\n"
-	@docker run --network host --rm --init -v $(PWD):/data $(IMAGE) python -m http.server 4000 --directory /data
+	@docker run -p 4000:4000 --rm --init -v $(PWD):/data $(IMAGE) python -m http.server 4000 --directory /data
 
 # Retrieve the data from the host machine
 get_data :

--- a/src/cli/biospring-cli.cpp
+++ b/src/cli/biospring-cli.cpp
@@ -164,7 +164,7 @@ CommandLineArguments::CommandLineArguments(const std::string & name, const argpa
                                   .name_long("--port")
                                   .description("Listening and outcoming port for MDDriver.")
                                   .argument_type(argparse::ArgumentType::INTEGER)
-                                  .default_value("3000");
+                                  .default_value("8888");
 
     argparse::Argument debug = argparse::Argument()
                                    .name_long("--debug")

--- a/src/cli/biospring-cli.h
+++ b/src/cli/biospring-cli.h
@@ -17,7 +17,7 @@ const std::string PROGRAM_VERSION = "biospring " + biospring::VERSION_STRING;
 struct MDDriverParameters
 {
     bool wait = true;
-    unsigned port = 3000;
+    unsigned port = 8888;
     unsigned debug = 0;
     std::string logpath = "";
     float forcescale = 1.0;

--- a/src/interactor/mddriver/InteractorMDDriver.cpp
+++ b/src/interactor/mddriver/InteractorMDDriver.cpp
@@ -22,7 +22,7 @@ InteractorMDDriver::InteractorMDDriver()
 	strcpy(_IMDlogfilename,"");
 	_IMDlog = NULL;
 	_IMDwait           = 1;
-	_IMDport           = 3000;
+	_IMDport           = 8888;
 	_IMDmode = 1; //server
 	_IMDforcescale =1.0;
 	_IMDenergies.tstep  = 0.0;

--- a/src/viewer/biospring-viewer.cpp
+++ b/src/viewer/biospring-viewer.cpp
@@ -54,7 +54,7 @@ int main(int argc, char ** argv)
 	{
 	bool openclok=true;
 	#ifdef MDDRIVER_SUPPORT
-   		unsigned port=3000;
+   		unsigned port=8888;
 		unsigned wait=1;
 		unsigned debug=0;
         	char logfilename[FILENAMEMAXSIZE]="";

--- a/src/viewer/biospring-viewer.cpp
+++ b/src/viewer/biospring-viewer.cpp
@@ -37,7 +37,7 @@ void usage()
 	#ifdef MDDRIVER_SUPPORT
 	cout<<"\tMDDriver support     MDDriver support is enabled : "<<endl;
 	cout<<"\t\tMDDriver is a library which extends the IMD protocol used in VMD for simulation and visualisation coupling."<<endl;
-	cout<<"\t\t[-port portnumber] 			(Listening and outcoming port for MDDriver with default = 3000)"<<endl;
+	cout<<"\t\t[-port portnumber] 			(Listening and outcoming port for MDDriver with default = 8888)"<<endl;
 	cout<<"\t\t[-wait 0 or 1]     			(Wait a connection before starting the simulation with default = 1 means wait)"<<endl;
 	cout<<"\t\t[-debug 0, 1 or 2] 	 		(Debug level of the MDDriver simulation with default = 0 means no debug message)"<<endl;
 	cout<<"\t\t[-log filename]     			(Filename for MDDriver debug messages with default = stdout)"<<endl;


### PR DESCRIPTION
This PR updates all occurrences of port 3000 to port 8888 to align with the default port used by UnityMol and GROMACS for IMD (Interactive Molecular Dynamics) communication.

Dependency:
⚠️ This PR depends on another PR in the related MDDriver repository: [https://github.com/LBT-CNRS/MDDriver/pull/7](https://github.com/LBT-CNRS/MDDriver/pull/7)
Please ensure that the linked PR is merged (and tested) before merging this one to avoid breaking compatibility.