### PR TITLE
Fix IMPALA cz(z): bare abs() truncates membrane depth to integer Å

### DIFF
--- a/src/forcefield/energy/imp.hpp
+++ b/src/forcefield/energy/imp.hpp
@@ -3,6 +3,8 @@
 
 #include "../constants.hpp"
 
+#include <cmath> // for std::fabs — bare abs() on a float binds to int abs(int)
+
 namespace biospring
 {
 namespace forcefield
@@ -35,8 +37,8 @@ inline float imp_energy(float x, float y, float z,
     double cz = 0.0;
 
     // membrane radius based on its curvature 
-    float uppermemb_radius = uppermembtubecurv == 0.0 ? 1000000 : abs(1/uppermembtubecurv);
-    float lowermemb_radius = lowermembtubecurv == 0.0 ? 1000000 : abs(1/lowermembtubecurv);
+    float uppermemb_radius = uppermembtubecurv == 0.0 ? 1000000 : std::fabs(1/uppermembtubecurv);
+    float lowermemb_radius = lowermembtubecurv == 0.0 ? 1000000 : std::fabs(1/lowermembtubecurv);
 
     // sign of curv (-1 or 1)
     int uppermemb_curv_sign = (uppermembtubecurv > 0.0) - (uppermembtubecurv < 0.0);
@@ -61,8 +63,8 @@ inline float imp_energy(float x, float y, float z,
             lowermemb_curv_sign * v_lower.norm() - lowermemboffset - lowermemb_radius : // Particle inside the lower tube membrane zone
             -lowermemb_curv_sign * v_lower.norm() - lowermemboffset - lowermemb_radius; // Particle outside the lower tube membrane zone
 
-    double cz_upper = 0.5 - 1.0 / (1.0 + exp(ALPHA * (abs(z_upper - uppermemboffset) - Z0)));
-    double cz_lower = 0.5 - 1.0 / (1.0 + exp(ALPHA * (abs(z_lower + lowermemboffset) - Z0)));
+    double cz_upper = 0.5 - 1.0 / (1.0 + exp(ALPHA * (std::fabs(z_upper - uppermemboffset) - Z0)));
+    double cz_lower = 0.5 - 1.0 / (1.0 + exp(ALPHA * (std::fabs(z_lower + lowermemboffset) - Z0)));
 
     double hydro_upper = -surface * transfer * cz_upper;
     double hydro_lower = -surface * transfer * cz_lower;
@@ -97,8 +99,8 @@ inline Vector3f imp_force_vector(float x, float y, float z,
                               float lowermembtubecurv=0.0)
 {
     // membrane radius based on its curvature 
-    float uppermemb_radius = uppermembtubecurv == 0.0 ? 1000000 : abs(1/uppermembtubecurv);
-    float lowermemb_radius = lowermembtubecurv == 0.0 ? 1000000 : abs(1/lowermembtubecurv);
+    float uppermemb_radius = uppermembtubecurv == 0.0 ? 1000000 : std::fabs(1/uppermembtubecurv);
+    float lowermemb_radius = lowermembtubecurv == 0.0 ? 1000000 : std::fabs(1/lowermembtubecurv);
 
     // sign of curv
     int uppermemb_curv_sign = (uppermembtubecurv > 0.0) - (uppermembtubecurv < 0.0);
@@ -123,14 +125,14 @@ inline Vector3f imp_force_vector(float x, float y, float z,
             lowermemb_curv_sign * v_lower.norm() - lowermemboffset - lowermemb_radius : // Particle inside the lower tube membrane zone
             -lowermemb_curv_sign * v_lower.norm() - lowermemboffset - lowermemb_radius; // Particle outside the lower tube membrane zone
 
-    auto expo_side = [](float z, float offset) { return exp(ALPHA * (abs(z + offset) - Z0)); };
+    auto expo_side = [](float z, float offset) { return exp(ALPHA * (std::fabs(z + offset) - Z0)); };
 
     double dcz_upper = (ALPHA * (z_upper - uppermemboffset) * expo_side(z_upper, -uppermemboffset)) / 
-                (pow(expo_side(z_upper, -uppermemboffset) + 1, 2.0) * abs(z_upper - uppermemboffset));
+                (pow(expo_side(z_upper, -uppermemboffset) + 1, 2.0) * std::fabs(z_upper - uppermemboffset));
     
 
     double dcz_lower = (ALPHA * (z_lower + lowermemboffset) * expo_side(z_lower, lowermemboffset)) / 
-                (pow(expo_side(z_lower, lowermemboffset) + 1, 2.0) * abs(z_lower + lowermemboffset));
+                (pow(expo_side(z_lower, lowermemboffset) + 1, 2.0) * std::fabs(z_lower + lowermemboffset));
     
     if (std::isnan(dcz_upper) || !std::isfinite(dcz_upper))
         dcz_upper = 0.0;


### PR DESCRIPTION
## The issue
`src/forcefield/energy/imp.hpp` includes only `../constants.hpp` — neither `<cmath>` nor `<cstdlib>` explicitly. The `exp`/`pow` calls resolve to float math via transitive includes, but the bare **`abs(...)`** calls on the `float`/`double` argument bind to C's **`int abs(int)`** (dragged in transitively from `<cstdlib>`). The floating-point argument is therefore implicitly truncated toward zero to a whole number **before** the membrane sigmoid `cz(z)`.

Net effect: the IMPALA insertion depth `z` is **quantised to whole Ångströms** — a bead at z = 15.75 Å is scored as if it were at z = 15 Å. The same `int`-`abs` appears in `imp_force_vector` (the `expo_side` term and the force denominator), so the force is also quantised and internally inconsistent with the (already-quantised) energy.

## Analysis / evidence
Found while validating a JAX re-implementation (`biospring_kups`) against this engine as the reference oracle. On a controlled 6-bead, IMPALA-only system (beads 100 Å apart so each SASA = 4π(r+probe)², scale 12, transfer 0.02):

| | IMP energy (kJ/mol) |
|---|---|
| BioSpring (this engine) | **−12.1444** |
| Physically-correct float abs | **−33.1068** |

The only beads that differ are those at non-integer z. On the real `snare-epr/lewitt` membrane system the same truncation produces a **1.6 %** error (1715.82 truncated vs 1688.20 continuous); `martini3` likewise. Every other input was verified identical between the two engines (SASA byte-identical, transfer = `hydrophobicityscale` byte-identical, ALPHA/Z0/ALIP and the `cz` formula match), so the integer truncation is the sole discrepancy.

## The fix
Add `#include <cmath>` and replace the bare `abs(...)` on floating-point arguments with `std::fabs(...)` at all sites:
- `imp_energy`: cz terms (the two `cz_upper`/`cz_lower` lines) and the `abs(1/curv)` membrane-radius terms;
- `imp_force_vector`: the `expo_side` lambda, the two force-denominator `abs(...)` terms, and the `abs(1/curv)` radius terms.

9 sites total. Verified to compile (`g++ -std=c++17 -fsyntax-only`).

## ⚠️ Compatibility
This is **not backwards-compatible**: every IMPALA energy and force changes, because insertion depth becomes continuous instead of integer-quantised. Any tuned membrane parameter sets / reference trajectories should be re-validated. If exact reproduction of historical runs is required, consider gating behind a version note or an MSP toggle.

## How it was validated
The JAX port reproduces this engine's IMP to ~1e-7 when it *replicates* the integer truncation, and to the continuous value when it doesn't — so the port can validate against this PR directly once merged. Background notes: `biospring-kups/docs/biospring_issues_found.md` §4.
