### PR TITLE
Fix segfault: guard pairwise Coulomb when neighbour-search unbuilt (grid+coulomb, #6)

### DIFF
--- a/src/spn/SpringNetwork.cpp
+++ b/src/spn/SpringNetwork.cpp
@@ -110,7 +110,12 @@ void SpringNetwork::computeParticleForces()
             // Compute electrostatic forces.
             if (isElectrostaticEnabled())
             {
-                if (isElectrostaticCoulombEnabled())
+                // Guard: the pairwise-Coulomb neighbour-search is only built when the
+                // potential-grid (electrostatic field) is OFF (see _setupElectrostatic).
+                // Without this guard, enabling potentialgrid + coulomb together derefs a
+                // null _nsearch.electrostatic here -> segfault. Skip pairwise Coulomb when
+                // its search was not built (grid mode).
+                if (isElectrostaticCoulombEnabled() && _nsearch.electrostatic != nullptr)
                 {
                     // p->addElectrostaticForceNoGrid(getElectrostaticCutoff());
                     if (p.isCharged())


### PR DESCRIPTION
## Summary
Fixes the segfault in **#6**: enabling a potential grid (`potentialgrid.enable=1`) together with Coulomb (`coulomb.enable=1`) crashes on the first charged particle.

## Root cause
`SpringNetwork::_setupElectrostatic` builds the Coulomb neighbour-search `_nsearch.electrostatic` **only in the field-OFF `else` branch**. But `computeParticleForces` runs the pairwise-Coulomb block whenever `isElectrostaticCoulombEnabled()` (= `electrostatic.enable`). With the grid enabled the search is never built, so `Particle::addElectrostaticForce` dereferences a null `unique_ptr` → SIGSEGV. (The e-field force needs `electrostatic.enable` + `potentialgrid.enable` + charged particles — exactly the crashing combination.)

## Fix
Guard the pairwise-Coulomb block on a non-null `_nsearch.electrostatic` (`SpringNetwork.cpp`). Minimal, preserves existing physics: grid-only runs stay grid-only (pairwise Coulomb is skipped in grid mode), and Coulomb-only runs are unchanged. Grid+Coulomb now runs with the field force.

## Verification
A charged 4-bead system with a linear-ramp `.dx` grid + `coulomb.enable=1`: **exit 139 before**, runs to completion **after**. Confirmed against a JAX re-implementation: the e-field force matches to rel 8.8e-5.

## Note (design choice for you)
This keeps grid and pairwise Coulomb **independent** (grid mode = field force only). If you instead want grid+Coulomb to apply *both* contributions, the fix would be to build the neighbour-search whenever `electrostatic.enable` (move `make_nsearch` out of the `else`) — happy to switch to that. A cleaner long-term option is a dedicated `electrostaticfield.enable` flag separate from `coulomb.enable`.
