### PR TITLE
Fix segfault: guard null _sasa in FreeSASA syncParticleStateData (startup race)

### DIFF
--- a/src/interactor/freesasa/InteractorFreeSASA.cpp
+++ b/src/interactor/freesasa/InteractorFreeSASA.cpp
@@ -223,6 +223,11 @@ void InteractorFreeSASA::syncSystemStateData()
 // based on FreeSASA-related computations.
 void InteractorFreeSASA::syncParticleStateData(unsigned index)
 {
+	// Guard against the first-step race: _sasa is allocated inside the FreeSASA
+	// worker thread (processFreesasaInteractions); the main thread's first
+	// idleRun -> syncParticleStateData can run before that allocation, derefing
+	// a null _sasa (segfault, lost for large N). No-op until SASA is ready.
+	if (_sasa == nullptr) return;
 	getSpringNetwork()->getParticle(index).setSolventAccessibilitySurface(_sasa[index]);
 }
 


### PR DESCRIPTION
## Summary
Fixes a startup **segfault** in the FreeSASA interactor that hits larger systems (observed: a ~1329-bead IMPALA system — OmpT membrane insertion — crashes before the first frame).

## Root cause
`_sasa` is `malloc`'d inside the FreeSASA **worker thread** (`processFreesasaInteractions`). The main thread's first `idleRun → Interactor::syncSystemStateData → InteractorFreeSASA::syncParticleStateData(j)` (`InteractorFreeSASA.cpp:226`) can run **before** that allocation, dereferencing a null `_sasa[j]` → SIGSEGV. It's a race: lost for large N (slow SASA compute), won for small N — so it looks intermittent/size-dependent.

## Fix
`if (_sasa == nullptr) return;` at the top of `syncParticleStateData` — the per-particle sync is a no-op until SASA is ready; a subsequent `idleRun` applies it once the worker finishes (static-SASA runs once, so it's applied by step ~1).

## Verification
A 1329-bead IMPALA system (rigid-body on or off): **exit 139 at startup before**, runs to completion (20+ frames) **after**. A 346-bead IMPALA system was unaffected either way (won the race).

## Related (not fixed here)
`processFreesasaInteractions` also writes `_sasa[i] = result->sasa[i]` in a loop that sits *outside* the `if (result != NULL)` guard — a latent null-deref if `freesasa_calc_coord` ever returns NULL. Out of scope for this crash, but worth tightening.
