### PR TITLE
Make the hydrophobic force usable from a .nc (fix segfault + load per-particle hydrophobicity)

### DIFF
--- a/src/IO/NetCDFReader.cpp
+++ b/src/IO/NetCDFReader.cpp
@@ -61,6 +61,10 @@ void NetCDFReader::addParticlesToSpn()
             // impProperties.set_transfert_energy_by_accessible_surface(_pbuffer.hscales[i]);
             // p.properties().imp().set_transfert_energy_by_accessible_surface(_pbuffer.hscales[i]);
 
+        // Per-particle hydrophobicity for the pairwise hydrophobic force term.
+        if (_pbuffer.hydrophobicities)
+            p.properties().set_hydrophobicity(_pbuffer.hydrophobicities[i]);
+
         _topology.add_particle(p);
     }
 }
@@ -162,6 +166,24 @@ void NetCDFReader::readParticles()
         checkNDims(data, 1);
         checkDim(data, 0, _pbuffer.number_of_particles);
         data.getVar(_pbuffer.hscales);
+    }
+
+    // Per-particle hydrophobicity for the pairwise hydrophobic FORCE term
+    // (Particle::getHydrophobicity()). Distinct from `hydrophobicityscale`, which
+    // above feeds the IMP transfer energy. Optional; previously only settable via
+    // pdb2spn's ForceFieldReader, so the term was inert when run from a .nc.
+    data = getNcVar("hydrophobicity", false);
+    if (not data.isNull())
+    {
+        checkNDims(data, 1);
+        checkDim(data, 0, _pbuffer.number_of_particles);
+        data.getVar(_pbuffer.hydrophobicities);
+    }
+    else
+    {
+        // Absent → default 0 (term inert), avoiding an uninitialised-buffer read.
+        for (size_t i = 0; i < _pbuffer.number_of_particles; ++i)
+            _pbuffer.hydrophobicities[i] = 0.0f;
     }
 }
 

--- a/src/IO/NetCDFWriter.cpp
+++ b/src/IO/NetCDFWriter.cpp
@@ -77,6 +77,9 @@ void NetCDFWriter::writeBinary()
     hscale.putAtt("units", "kJ.mol-1");
     hscale.putAtt("long_name", "Particle hydrophobicity scale (transfer energy)");
 
+    NcVar hydrophobicity = nc->addVar("hydrophobicity", ncFloat, pnbdim);
+    hydrophobicity.putAtt("long_name", "Particle hydrophobicity (pairwise hydrophobic force)");
+
     NcVar resids = nc->addVar("resids", ncInt, pnbdim);
     resids.putAtt("long_name", "Particle residue id");
 
@@ -110,6 +113,7 @@ void NetCDFWriter::writeBinary()
     charges.putVar(pbuffer.charges);
     surfacc.putVar(pbuffer.surface_accessibilities);
     hscale.putVar(pbuffer.hscales);
+    hydrophobicity.putVar(pbuffer.hydrophobicities);
     chainnames.putVar(pbuffer.chainnames);
     pnames.putVar(pbuffer.particlenames);
     resnames.putVar(pbuffer.resnames);

--- a/src/IO/SpnBuffer.h
+++ b/src/IO/SpnBuffer.h
@@ -88,6 +88,7 @@ struct ParticleBuffer
     float * epsilons;
     float * masses;
     float * hscales;
+    float * hydrophobicities;
     float * surface_accessibilities;
 
     int * ids;
@@ -111,6 +112,7 @@ struct ParticleBuffer
             epsilons = new float[nParticles];
             masses = new float[nParticles];
             hscales = new float[nParticles];
+            hydrophobicities = new float[nParticles];
             surface_accessibilities = new float[nParticles];
             ids = new int[nParticles];
             resids = new int[nParticles];
@@ -138,6 +140,7 @@ struct ParticleBuffer
             epsilons[i] = p.getEpsilon();
             masses[i] = p.getMass();
             hscales[i] = p.getTransferEnergyByAccessibleSurface();
+            hydrophobicities[i] = p.getHydrophobicity();
 
             ids[i] = p.getId();
             resids[i] = p.getResId();
@@ -156,7 +159,8 @@ struct ParticleBuffer
     //
     ParticleBuffer()
         : number_of_particles(0), coordinates(0), charges(0), radii(0), epsilons(0), masses(0), hscales(0),
-          surface_accessibilities(0), ids(0), resids(0), dynamic_states(0), chainnames(0), particlenames(0), resnames(0)
+          hydrophobicities(0), surface_accessibilities(0), ids(0), resids(0), dynamic_states(0), chainnames(0),
+          particlenames(0), resnames(0)
     {
     }
 
@@ -174,6 +178,7 @@ struct ParticleBuffer
         delete epsilons;
         delete masses;
         delete hscales;
+        delete hydrophobicities;
         delete surface_accessibilities;
         delete ids;
         delete resids;

--- a/src/spn/SpringNetwork.cpp
+++ b/src/spn/SpringNetwork.cpp
@@ -604,6 +604,11 @@ void SpringNetwork::setup(const configuration::Configuration & conf)
     _setupForceField();
     _setupSteric();
     _setupElectrostatic();
+    // _setupHydrophobic() builds _nsearch.hydrophobic; without this call it stays
+    // null and Particle::addHydrophobicityForce() dereferences it -> SIGSEGV on any
+    // hydrophobicity.enable=1 run. (Same class as the steric/electrostatic nsearch
+    // setups above.)
+    _setupHydrophobic();
     _setupDensityGrid();
     _setupProbe();
     _setupInsertionVector();


### PR DESCRIPTION
The pairwise **hydrophobic force** (`hydrophobicity.enable=1`) was unusable when a
system is run from a `.nc` topology, for two independent reasons. This PR fixes
both; with them, the term runs and produces the expected per-particle force.

### 1. Segfault — `_setupHydrophobic()` is never called
`SpringNetwork::setup()` calls `_setupForceField/_setupSteric/_setupElectrostatic/
_setupDensityGrid/_setupProbe/_setupInsertionVector/_setupTrajectories` but **not**
`_setupHydrophobic()`. That method (which builds `_nsearch.hydrophobic`) is defined
but has zero call-sites, so `_nsearch.hydrophobic` stays null and the first step
makes `Particle::addHydrophobicityForce()` dereference
`getNeighborSearch().hydrophobic->get_neighbors(*this)` on a null pointer → SIGSEGV
on any `hydrophobicity.enable=1` run. (Same class as the grid+Coulomb and FreeSASA
null-`_nsearch` segfaults.) Fix: add the missing call.

### 2. The force was inert — no `.nc` input for `particle.hydrophobicity`
Even with the crash fixed, the force was **structurally zero** when run from a
`.nc`: nothing sets `Particle::getHydrophobicity()` (the value the force uses). The
`.nc` `hydrophobicityscale` variable is consumed as the **IMP transfer energy**
(`NetCDFReader.cpp`), and the hydrophobic-force value was only ever set by pdb2spn's
`ForceFieldReader` (from a `.ff` file), never restored from a `.nc`. Fix: add an
optional per-particle **`hydrophobicity`** `.nc` variable, **symmetric read+write**:
a `ParticleBuffer` field, a `NetCDFReader` block (`properties().set_hydrophobicity(...)`,
absent → 0 so existing `.nc` files are unaffected), and a `NetCDFWriter` var+`putVar`
for round-trip. The existing topology→spn copy carries it to the runtime particle.

### Verification
Validated against an independent reimplementation (a JAX port of the force field):
on a synthetic N=5 cluster within the 15 Å cutoff, the engine's emitted per-particle
hydrophobic force matches the reference formula to **max|Δ| = 2.77e-7** (force
magnitude ~0.12). Built + tested via a patched Docker image; existing systems
(spring/steric/Coulomb/IMPALA/e-field) unaffected.

Sibling segfault fixes: #7 (grid+Coulomb), #8 (FreeSASA).

Note (separate, pre-existing, out of scope): `hydrophobic_force_module` in
`forcefield/energy/hydrophobic.hpp` applies the J→kJ `1e-3` factor twice (force is
~1e3 smaller than the energy gradient implies) — users compensate with tiny `h`.
The validation above confirms the engine matches the reference **including** this
bug; the unit fix is flagged for a follow-up.