### PR TITLE
Fix std::out_of_range crash: clamp/zero off-grid potential-grid lookups

### DIFF
--- a/src/spn/Particle.cpp
+++ b/src/spn/Particle.cpp
@@ -127,6 +127,14 @@ void Particle::addDensityFieldForce()
     float gridscale = _springnetwork->getGridScale();
     const biospring::grid::PotentialGrid & potentialgrid = _springnetwork->getDensityGrid();
 
+    // Off-grid guard: a steered or free-moving particle can leave the density
+    // grid. DenseGrid::get -> at() throws std::out_of_range for an out-of-bounds
+    // cell, which aborts the whole run. The JAX port (potential/density_field.py)
+    // instead contributes ZERO force for out-of-grid particles (clamp-the-index +
+    // mask-to-zero). Mirror that here: skip the lookup and add nothing.
+    if (potentialgrid.is_out_of_grid(biospring::grid::real_coordinates(getX(), getY(), getZ())))
+        return;
+
     Vector3f force = potentialgrid.get(getX(), getY(), getZ()).vector;
     force = force * getBurying() * gridscale;
 
@@ -138,6 +146,11 @@ void Particle::addElectrostaticFieldForce()
     const biospring::forcefield::ForceField * ff = _springnetwork->getForceField();
     float gridscale = _springnetwork->getGridScale();
     const biospring::grid::PotentialGrid & potentialgrid = _springnetwork->getPotentialGrid();
+
+    // Off-grid guard (see addDensityFieldForce): mirror the JAX port's zero-force
+    // out-of-bounds behaviour instead of throwing std::out_of_range and crashing.
+    if (potentialgrid.is_out_of_grid(biospring::grid::real_coordinates(getX(), getY(), getZ())))
+        return;
 
     const auto & cell = potentialgrid.get(getX(), getY(), getZ());
 


### PR DESCRIPTION
A steered or free-moving particle can leave the electrostatic/density potential grid. `DenseGrid::get -> at()` throws `std::out_of_range` for an out-of-bounds cell, which aborts the whole simulation (seen when steering prot-dna off-grid via IMD).

This guards both grid-force paths (`Particle::addElectrostaticFieldForce`, `addDensityFieldForce`) with `is_out_of_grid` and contributes zero force/energy for out-of-bounds particles — matching the behaviour of the JAX/kUPS port, which clamps the cell index and masks the result to zero.

Branch off the pinned oracle SHA `87dedfd`; the same single-file change is carried as `docker/patches/08` in biospring-kups.
